### PR TITLE
fix: sidebar react vs next conflict

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useNavigate } from "react-router-dom";
 import { 
   MessageSquare, 
   Users, 
@@ -22,7 +22,7 @@ import {
 
 const Sidebar = () => {
   const { logout, state: { user } } = useAuth();
-  const router = useRouter();
+  const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(false);
 
   const sidebarItems = [
@@ -97,7 +97,7 @@ const Sidebar = () => {
                   <TooltipTrigger asChild>
                     <Button
                       variant="ghost"
-                      onClick={() => router.push(item.path)}
+                      onClick={() => navigate(item.path)}
                       className={cn(
                         "w-full justify-start",
                         collapsed ? "px-2" : "px-3"


### PR DESCRIPTION
Changed useRouter to useNavigate  in app/src/components/layout/Sidebar.tsx, as AppLayout.tsx uses Outlet from react-router-dom, providing a React.js environment. This is a temporary fix for rendering issue of the sidebar, needs further review. .../shared/ route is not getting rendered still, could be another routing conflict, needs review.